### PR TITLE
Update compiler plugin API usage and bump dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
+ksp.useKSP2=true

--- a/kotlinx-gettext-plugin/build.gradle.kts
+++ b/kotlinx-gettext-plugin/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable")
 
     compileOnly("com.google.auto.service:auto-service-annotations:1.0.1")
-    ksp("dev.zacsweers.autoservice:auto-service-ksp:1.1.0")
+    ksp("dev.zacsweers.autoservice:auto-service-ksp:1.2.0")
 
     testImplementation(kotlin("test"))
     testCompileOnly("com.google.auto.service:auto-service-annotations:1.1.1")

--- a/kotlinx-gettext-plugin/src/main/kotlin/GettextCompilerPluginRegistrar.kt
+++ b/kotlinx-gettext-plugin/src/main/kotlin/GettextCompilerPluginRegistrar.kt
@@ -21,8 +21,7 @@ import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.com.intellij.mock.MockProject
-import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import java.io.File
@@ -30,11 +29,11 @@ import java.io.File
 const val KOTLIN_PLUGIN_ID = "name.kropp.kotlinx-gettext"
 
 @OptIn(ExperimentalCompilerApi::class)
-@AutoService(ComponentRegistrar::class)
-class GettextComponentRegistrar(
+@AutoService(CompilerPluginRegistrar::class)
+class GettextCompilerPluginRegistrar(
     private val defaultPotFile: String,
     private val defaultKeywords: List<String>,
-) : ComponentRegistrar {
+) : CompilerPluginRegistrar() {
 
     @Suppress("unused") // Used by service loader
     constructor() : this(
@@ -42,10 +41,10 @@ class GettextComponentRegistrar(
         defaultKeywords = listOf("tr"),
     )
 
-    override fun registerProjectComponents(
-        project: MockProject,
-        configuration: CompilerConfiguration
-    ) {
+    override val supportsK2: Boolean
+        get() = true
+
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
         val file = File(configuration.get(GettextCommandLineProcessor.ARG_POT_FILE, defaultPotFile))
         runCatching { file.parentFile.mkdirs() }
@@ -58,6 +57,6 @@ class GettextComponentRegistrar(
 
         val extension = GettextIrGenerationExtension(messageCollector, keywords, basePath, overwrite, file)
 
-        IrGenerationExtension.registerExtension(project, extension)
+        IrGenerationExtension.registerExtension(extension)
     }
 }

--- a/kotlinx-gettext-plugin/src/test/kotlin/SmokeTest.kt
+++ b/kotlinx-gettext-plugin/src/test/kotlin/SmokeTest.kt
@@ -137,13 +137,12 @@ fun trc(ctx: String, text: String) {}
         assertEquals("$DEFAULT_POT_HEADER\n\n#: main.kt:2\nmsgid \"Hello,\\n\\\"World\\\"!\"\nmsgstr \"\"\n", potFile)
     }
 
-    @Suppress("DEPRECATION")
     @OptIn(ExperimentalCompilerApi::class)
     private fun compile(vararg sourceFile: SourceFile, defaultKeywords: List<String> = listOf("tr")): KotlinCompilation.Result {
         return KotlinCompilation().apply {
             sources = sourceFile.toList()
             useIR = true
-            componentRegistrars = listOf(GettextComponentRegistrar(File(workingDir, "i18n.pot").absolutePath, defaultKeywords))
+            compilerPluginRegistrars = listOf(GettextCompilerPluginRegistrar(File(workingDir, "i18n.pot").absolutePath, defaultKeywords))
             inheritClassPath = true
         }.compile()
     }


### PR DESCRIPTION
Replaced deprecated `componentRegistrars` with `compilerPluginRegistrars` for compatibility with the latest Kotlin API